### PR TITLE
NovaPunch2 wings and an approximation of FSairBrake support

### DIFF
--- a/GameData/FerramAerospaceResearch/FerramAerospaceResearch.cfg
+++ b/GameData/FerramAerospaceResearch/FerramAerospaceResearch.cfg
@@ -451,3 +451,11 @@
 		TaperRatio = 0.677
 	}
 }
+@PART[*]:HAS[@MODULE[FSairBrake]]:FOR[FerramAerospaceResearch]
+{
+	@maximum_drag = 0
+	@MODULE[FSairBrake]
+	{
+		@deployedDrag *= 0.2
+	}
+}


### PR DESCRIPTION
The NP2 stuff should be straight-forward.

Since properly supporting FSairBrake would require code as its a mesh rotation and not an animation, this is just a multiplier.

1/5th of the stock value seems to work ok, which is to say airbrakes arent as ludicrously powerful as they are when using stock stock numbers, but they're still some use.

It might still need tuning, but right now FSairBrake work more like magical drogue chutes in FAR, and this goes a decent way towards making them behave sort of similarly to proper FAR spoilers.
