### PR TITLE
Different control surface deflection speeds for stick inputs and flap/sp...

### DIFF
--- a/FerramAerospaceResearch/FARAeroUtil.cs
+++ b/FerramAerospaceResearch/FARAeroUtil.cs
@@ -76,6 +76,7 @@ namespace ferram4
             node.AddValue("%incompressibleRearAttachDrag", incompressibleRearAttachDrag);
             node.AddValue("%sonicRearAdditionalAttachDrag", sonicRearAdditionalAttachDrag);
             node.AddValue("%ctrlSurfTimeConstant", FARControllableSurface.timeConstant);
+            node.AddValue("%ctrlSurfTimeConstantFlap", FARControllableSurface.timeConstantFlap);
 
             node.AddNode(new ConfigNode("!BodyAtmosphericData,*"));
 
@@ -125,6 +126,9 @@ namespace ferram4
 
                 if (node.HasValue("ctrlSurfTimeConstant"))
                     double.TryParse(node.GetValue("ctrlSurfTimeConstant"), out FARControllableSurface.timeConstant);
+
+                if (node.HasValue("ctrlSurfTimeConstantFlap"))
+                    double.TryParse(node.GetValue("ctrlSurfTimeConstantFlap"), out FARControllableSurface.timeConstantFlap);
 
                 FARAeroUtil.bodyAtmosphereConfiguration = new Dictionary<int, Vector3d>();
                 foreach (ConfigNode bodyProperties in node.GetNodes("BodyAtmosphericData"))

--- a/FerramAerospaceResearch/FARDebugOptions.cs
+++ b/FerramAerospaceResearch/FARDebugOptions.cs
@@ -206,6 +206,11 @@ namespace ferram4
             tmp = Regex.Replace(tmp, @"[^-?\d*\.?\d*]", "");
             FARControllableSurface.timeConstant = Convert.ToDouble(tmp);
 
+            tmp = FARControllableSurface.timeConstantFlap.ToString();
+            TextEntryField("Flap/Spoiler Time Constant:", 160, ref tmp);
+            tmp = Regex.Replace(tmp, @"[^-?\d*\.?\d*]", "");
+            FARControllableSurface.timeConstantFlap = Convert.ToDouble(tmp);
+
             GUILayout.EndVertical();
             GUILayout.BeginVertical();
             GUILayout.Label("Celestial Body Atmosperic Properties");


### PR DESCRIPTION
This patch gives an extra time constant to flaps and spoiler deflection so you can make flaps and spoilers "state" changes slower (or faster) than deflections due to control input. To do so, the desired deflection (AoAoffset) is split into a contribution from flaps/spoilers and a contribution from control inputs. There are now corresponding "desired" and "current" values for both of those in order to enable both contributions to vary at different rates. The patch also comes with a gui element for the new time constant.
