### PR TITLE
ModuleLandingGear fixes for 0.25

### DIFF
--- a/GameData/FerramAerospaceResearch/FerramAerospaceResearch.cfg
+++ b/GameData/FerramAerospaceResearch/FerramAerospaceResearch.cfg
@@ -511,3 +511,15 @@ MODULE
 		}
 	}
 }
+
+@PART[*]:HAS[@MODULE[ModuleLandingGear]]:FOR[FerramAerospaceResearch]
+{
+	@maximum_drag = 0
+	@MODULE[ModuleLandingGear]
+	{
+		%deployedDragMax = 0
+		%deployedDragMin = 0
+		%stowedDragMax = 0
+		%stowedDragMin = 0
+	}
+}


### PR DESCRIPTION
Since in 0.25 physics significance = 1 is not hardcoded in the PartModule any longer, its possible to have stock-module landing gear with actual drag and such.

Quick slap-fix, set drag to 0 and the partmodule's drag overrides to 0 too.
