### PR TITLE
Added FARWind class

### DIFF
--- a/FerramAerospaceResearch/FARBaseAerodynamics.cs
+++ b/FerramAerospaceResearch/FARBaseAerodynamics.cs
@@ -138,7 +138,7 @@ namespace ferram4
         {
             if (HighLogic.LoadedSceneIsFlight)
                 return part.Rigidbody.velocity + Krakensbane.GetFrameVelocityV3f()
-                    + FARWind.GetWind(FlightGlobals.currentMainBody, part.Rigidbody.position);
+                    + FARWind.GetWind(FlightGlobals.currentMainBody, part, part.Rigidbody.position);
             else
                 return velocityEditor;
         }
@@ -152,7 +152,7 @@ namespace ferram4
                     velocity += part.Rigidbody.GetPointVelocity(refPoint);
 
                 velocity += Krakensbane.GetFrameVelocity() - Krakensbane.GetLastCorrection() * TimeWarp.fixedDeltaTime;
-                velocity += FARWind.GetWind(FlightGlobals.currentMainBody, part.Rigidbody.position);
+                velocity += FARWind.GetWind(FlightGlobals.currentMainBody, part, part.Rigidbody.position);
 
                 return velocity;
             }

--- a/FerramAerospaceResearch/FARBasicDragModel.cs
+++ b/FerramAerospaceResearch/FARBasicDragModel.cs
@@ -305,7 +305,7 @@ namespace ferram4
                     if (rb && (object)vessel != null && vessel.atmDensity > 0)
                     {
                         Vector3d velocity = rb.velocity + Krakensbane.GetFrameVelocity()
-                            + FARWind.GetWind(FlightGlobals.currentMainBody, rb.position);
+                            + FARWind.GetWind(FlightGlobals.currentMainBody, part, rb.position);
 
                         double soundspeed, v_scalar = velocity.magnitude;
 

--- a/FerramAerospaceResearch/FARWind.cs
+++ b/FerramAerospaceResearch/FARWind.cs
@@ -17,7 +17,7 @@ namespace ferram4
         /// A WindFunction takes the current celestial body and a position (should be the position of the part)
         /// and returns the wind as a Vector3 (unit is m/s)
         /// </summary>
-        public delegate Vector3 WindFunction(CelestialBody body, Vector3 position);
+        public delegate Vector3 WindFunction(CelestialBody body, Part part, Vector3 position);
 
 
         /// <summary>
@@ -31,11 +31,11 @@ namespace ferram4
         /// If any exception occurs, it is suppressed and Vector3.zero is returned.
         /// This function will never throw, (although it will spam the log).
         /// </summary>
-        public static Vector3 GetWind(CelestialBody body, Vector3 position)
+        public static Vector3 GetWind(CelestialBody body, Part part, Vector3 position)
         {
             try
             {
-                return func(body, position);
+                return func(body, part, position);
             }
             catch (Exception e)
             {
@@ -64,7 +64,7 @@ namespace ferram4
         }
 
 
-        public static Vector3 ZeroWind(CelestialBody body, Vector3 position)
+        public static Vector3 ZeroWind(CelestialBody body, Part part, Vector3 position)
         {
             return Vector3.zero;
         }        

--- a/FerramAerospaceResearch/FARWingAerodynamicModel.cs
+++ b/FerramAerospaceResearch/FARWingAerodynamicModel.cs
@@ -403,7 +403,7 @@ namespace ferram4
                     CurWingCentroid = WingCentroid();
 
                     Vector3d velocity = rb.GetPointVelocity(CurWingCentroid) + Krakensbane.GetFrameVelocity()
-                        + FARWind.GetWind(FlightGlobals.currentMainBody, rb.position);
+                        + FARWind.GetWind(FlightGlobals.currentMainBody, part, rb.position);
 
                     double soundspeed, v_scalar = velocity.magnitude;
 


### PR DESCRIPTION
Implemented the FARWind class that acts as an entry point for other mods to add wind.
The Wind velocity is included in (hopefully all) the relevant calculations.

As I anticipated in IRC, this is a completely static class that never throws anything, so at worst it won't work but it shouldn't bring the rest of FAR with it. I think I found all the points where the wind velocity needed to be added: I searched for "Krakensbane" and corrected the velocity adding the wind.

I also checked for each use of "vel", but I didn't find any other point where the wind needs to be considered (then again, I know nothing about how you simulate the airflow, so I might have missed some).
