### PR TITLE
Opt out of up vector guess when intake not yet ready.

### DIFF
--- a/FerramAerospaceResearch/FARGeoUtil.cs
+++ b/FerramAerospaceResearch/FARGeoUtil.cs
@@ -306,7 +306,10 @@ namespace ferram4
             {
                 ModuleResourceIntake i = part.Modules["ModuleResourceIntake"] as ModuleResourceIntake;
                 Transform intakeTrans = part.FindModelTransform(i.intakeTransformName);
-                return part.transform.InverseTransformDirection(intakeTrans.forward);
+                if ((object) intakeTrans != null)
+                {
+                    return part.transform.InverseTransformDirection(intakeTrans.forward);
+                }
             }
             // If surface attachable, and node normal is up, check stack nodes or use forward
             else if (part.srfAttachNode != null &&


### PR DESCRIPTION
TweakScale rescales things during OnLoad when reverting to launch. At this point moduleResourceIntakes are not yet fully set up, and FARGeoUtil.GuessUpVector throws a NullReferenceException.

It may be that this is a more general problem and should be fixed in TweakScale instead (by not calling updaters and using exponents until the first call to Update, e.g.). Comments?
