### PR TITLE
a new IVA speedometer implementation

### DIFF
--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
@@ -77,6 +77,10 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         StabilityAugmentation _stabilityAugmentation;
         FlightDataGUI _flightDataGUI;
         AirspeedSettingsGUI _airSpeedGUI;
+        public AirspeedSettingsGUI airSpeedGUI
+        {
+            get { return _airSpeedGUI; }
+        }
 
         bool showFlightDataWindow = false;
         bool showSettingsWindow = false;

--- a/GameData/FerramAerospaceResearch/speedometerReplacement.cfg
+++ b/GameData/FerramAerospaceResearch/speedometerReplacement.cfg
@@ -1,0 +1,9 @@
+@PROP[ledPanelSpeed]
+{
+  // DaMichel: curly braces?! does not work without??!
+  !MODULE[InternalSpeed] {}
+  MODULE
+  {
+    name = InternalSpeedFAR
+  }
+}


### PR DESCRIPTION
This patch removes the evil IVA speedometer hack. This looks much less evil. At least it fixes the issue when Kerbals are transferred between modules. https://github.com/ferram4/Ferram-Aerospace-Research/issues/65

IVA speedometers are now handled by a subclass of InternalSpeed. To support that, minor changes to FlightGUI  and AirspeedSettingsGUI  were made.