### PR TITLE
Fix the NRE for EVA kerbals.

### DIFF
--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
@@ -161,7 +161,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
             if (useWingArea)
                 vesselInfo.refArea = wingArea;
-            else if (_vesselAero)
+            else if (_vesselAero && _vesselAero.enabled)
                 vesselInfo.refArea = _vesselAero.MaxCrossSectionArea;
             else
                 vesselInfo.refArea = 1;


### PR DESCRIPTION
_vesselAero is disabled for EVA kerbals and thus attempting to fetch the
area causes an NRE.