### PR TITLE
Bail out of ResetEditorEvent if there is no root part.

### DIFF
--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/EditorGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/EditorGUI.cs
@@ -201,7 +201,7 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI
         #region EditorEvents
         private void ResetEditorEvent(ShipConstruct construct)
         {
-            if (EditorLogic.SortedShipList.Count > 0)
+            if (EditorLogic.RootPart != null)
             {
                 List<Part> partsList = EditorLogic.SortedShipList;
                 for (int i = 0; i < partsList.Count; i++)


### PR DESCRIPTION
Various mods (in this case, KIS) will trigger editor events before
EditorLogic.RootPart has been set. SortedShipList uses RootPart and thus
will throw an NRE if used before RootPart has been set. Thus check RootPart
instead of the number of parts in SortedShipList (logically the same
effect).