### PR TITLE
Use a better test for vessel aero validity.

### DIFF
--- a/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
@@ -148,6 +148,8 @@ namespace FerramAerospaceResearch.FARAeroComponents
 
         private void FixedUpdate()
         {
+            if (_vehicleAero == null)
+                return;
             if (_vehicleAero.CalculationCompleted)
             {
                 _vehicleAero.GetNewAeroData(out _currentAeroModules, out _unusedAeroModules, out _currentAeroSections, out _legacyWingModels);                

--- a/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/FARVesselAero.cs
@@ -62,6 +62,11 @@ namespace FerramAerospaceResearch.FARAeroComponents
             get { return _vehicleAero.Length; }
         }
 
+		public bool isValid
+		{
+			get { return enabled && _vehicleAero != null; }
+		}
+
         public double MaxCrossSectionArea
         {
             get { return _vehicleAero.MaxCrossSectionArea; }

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/PhysicsCalcs.cs
@@ -161,7 +161,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
             if (useWingArea)
                 vesselInfo.refArea = wingArea;
-            else if (_vesselAero && _vesselAero.enabled)
+            else if (_vesselAero && _vesselAero.isValid)
                 vesselInfo.refArea = _vesselAero.MaxCrossSectionArea;
             else
                 vesselInfo.refArea = 1;


### PR DESCRIPTION
It turns out that checking just enabled is not enough, so check that
_vehicleAero is not null, too (via a property as _vehicleAero is private).

I'm not certain this is the correct fix as _vehicleAero being null may be a sign of other problems.