### PR TITLE
Use OnActive instead of FixedUpdate for staging.

### DIFF
--- a/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
+++ b/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
@@ -756,7 +756,7 @@ namespace FerramAerospaceResearch.RealChuteLite
             Vector3 velocity = this.part.Rigidbody.velocity + Krakensbane.GetFrameVelocityV3f();
             this.sqrSpeed = velocity.sqrMagnitude;
             this.dragVector = -velocity.normalized;
-            //if (!this.staged && GameSettings.LAUNCH_STAGES.GetKeyDown() && this.vessel.isActiveVessel && (this.part.inverseStage == Staging.CurrentStage - 1 || Staging.CurrentStage == 0)) { ActivateRC(); }
+            if (!this.staged && GameSettings.LAUNCH_STAGES.GetKeyDown() && this.vessel.isActiveVessel && (this.part.inverseStage == Staging.CurrentStage - 1 || Staging.CurrentStage == 0)) { ActivateRC(); }
 
             if (this.staged)
             {

--- a/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
+++ b/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
@@ -731,6 +731,14 @@ namespace FerramAerospaceResearch.RealChuteLite
             this.repack.guiActiveUnfocused = this.canRepack;
         }
 
+        public override void OnActive ()
+        {
+            if (!this.staged)
+            {
+                ActivateRC ();
+            }
+        }
+
         private void FixedUpdate()
         {
             //Flight values
@@ -748,7 +756,7 @@ namespace FerramAerospaceResearch.RealChuteLite
             Vector3 velocity = this.part.Rigidbody.velocity + Krakensbane.GetFrameVelocityV3f();
             this.sqrSpeed = velocity.sqrMagnitude;
             this.dragVector = -velocity.normalized;
-            if (!this.staged && GameSettings.LAUNCH_STAGES.GetKeyDown() && this.vessel.isActiveVessel && (this.part.inverseStage == Staging.CurrentStage - 1 || Staging.CurrentStage == 0)) { ActivateRC(); }
+            //if (!this.staged && GameSettings.LAUNCH_STAGES.GetKeyDown() && this.vessel.isActiveVessel && (this.part.inverseStage == Staging.CurrentStage - 1 || Staging.CurrentStage == 0)) { ActivateRC(); }
 
             if (this.staged)
             {


### PR DESCRIPTION
This allows parachutes to be deployed on drop-pods without having to switch
to the pod.

Also, this is similar to how the full RealChutes does it (the main difference is full RC still has the activation in FixedUpdate).