### PR TITLE
Don't change gimbal when RO is installed

### DIFF
--- a/GameData/FerramAerospaceResearch/stockEngineGimbalIncrease.cfg
+++ b/GameData/FerramAerospaceResearch/stockEngineGimbalIncrease.cfg
@@ -1,4 +1,4 @@
-@PART[*]:HAS[@MODULE[ModuleGimbal]]:Final
+@PART[*]:HAS[@MODULE[ModuleGimbal]]:NEEDS[!RealismOverhaul]:FINAL
 {
 	@MODULE[ModuleGimbal]
 	{


### PR DESCRIPTION
Didn't this patch use to be in? When did the NEEDS get removed?