### PR TITLE
Chutes - next try

### DIFF
--- a/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
+++ b/FerramAerospaceResearch/RealChuteLite/RealChuteFAR.cs
@@ -667,7 +667,7 @@ namespace FerramAerospaceResearch.RealChuteLite
         public void AssumeDragCubePosition(string name)
         {
             if (string.IsNullOrEmpty(name)) { return; }
-            EnsureAnimationSystemIsUsable();
+            InitializeAnimationSystem();
             switch (name)
             {
                 //DaMichel: now we handle the stock behaviour, too.
@@ -844,20 +844,17 @@ namespace FerramAerospaceResearch.RealChuteLite
         #endregion
 
         // DaMichel: functionality was in OnStart before. Now it is here so it can be used in  AssumeDragCubePosition
-        private void EnsureAnimationSystemIsUsable()
+        private void InitializeAnimationSystem()
         {
-            if (this.anim == null)
-            {
-                //I know this seems random, but trust me, it's needed, else some parachutes don't animate, because fuck you, that's why.
-                this.anim = this.part.FindModelAnimators(this.capName).FirstOrDefault();
+            //I know this seems random, but trust me, it's needed, else some parachutes don't animate, because fuck you, that's why.
+            this.anim = this.part.FindModelAnimators(this.capName).FirstOrDefault();
 
-                this.cap = this.part.FindModelTransform(this.capName);
-                this.parachute = this.part.FindModelTransform(this.canopyName);
-                this.parachute.gameObject.SetActive(true);
-                this.part.InitiateAnimation(this.semiDeployedAnimation);
-                this.part.InitiateAnimation(this.fullyDeployedAnimation);
-                this.parachute.gameObject.SetActive(false);
-            }
+            this.cap = this.part.FindModelTransform(this.capName);
+            this.parachute = this.part.FindModelTransform(this.canopyName);
+            this.parachute.gameObject.SetActive(true);
+            this.part.InitiateAnimation(this.semiDeployedAnimation); // disables animation states
+            this.part.InitiateAnimation(this.fullyDeployedAnimation);
+            this.parachute.gameObject.SetActive(false);
         }
 
 
@@ -880,7 +877,7 @@ namespace FerramAerospaceResearch.RealChuteLite
 
             //Staging icon
             this.part.stagingIcon = "PARACHUTES";
-            EnsureAnimationSystemIsUsable();
+            InitializeAnimationSystem();
 
             //First initiation of the part
             if (!this.initiated)

--- a/GameData/FerramAerospaceResearch/RealChuteLite/RealChuteLite.cfg
+++ b/GameData/FerramAerospaceResearch/RealChuteLite/RealChuteLite.cfg
@@ -1,7 +1,7 @@
 @PART[*]:HAS[@MODULE[ModuleParachute]]:NEEDS[!RealChute]:FOR[FerramAerospaceResearch]
 {
-        //Copies ModuleParachute to transform it into RealChute
-        +MODULE[ModuleParachute]
+        //Transform ModuleParachute into RealChute (removing ModuleParachute)
+        @MODULE[ModuleParachute]
         {
                 @name = RealChuteFAR
         }


### PR DESCRIPTION
Following up on the previous PR, here  are the cleaned changes.

I implemented your suggestion to disable other animation states for `AssumeDragCubePosition` by doing all the animation initialization within `AssumeDragCubePosition` via `InitializeAnimationSystem`  on each call. `this.part.InitiateAnimation` is called within `InitializeAnimationSystem` disabling the animation states. After that one of the states may be re-enabled - either deployed, semideployed or neither of them.

I tested the code (briefly tbh.) with simple fall tests, including quicksaving and reloading and it seemed to work. Computed drag cube parameters in partdatabase.cfg look sensible as well.