### PR TITLE
refixed typo - Invalid double value #114

### DIFF
--- a/GameData/FerramAerospaceResearch/FerramAerospaceResearch.cfg
+++ b/GameData/FerramAerospaceResearch/FerramAerospaceResearch.cfg
@@ -244,7 +244,7 @@ MODULE
 {
 name = FARWingAerodynamicModel
 MAC = 1.43
-MidChordSweep = 33/307
+MidChordSweep = 33.307
 b_2 = 3.806
 TaperRatio = 0.39512
 }


### PR DESCRIPTION
I reported this and the next day you've "Fixed in latest commit.": "Fix config error"
Unfortunately you've reversed it before release: "some sanity changes to intake drag and FARControllableSurface"