### PR TITLE
fixed issues with Unity API used outside of the main thread

### DIFF
--- a/FerramAerospaceResearch/FARAeroComponents/FARAeroSection.cs
+++ b/FerramAerospaceResearch/FARAeroComponents/FARAeroSection.cs
@@ -88,7 +88,7 @@ namespace FerramAerospaceResearch.FARAeroComponents
             xForcePressureAoA180 = new FARFloatCurve(6);
             xForceSkinFriction = new FARFloatCurve(3);
             partData = new List<PartData>();
-            handledAeroModulesIndexDict = new Dictionary<FARAeroPartModule, int>();
+            handledAeroModulesIndexDict = new Dictionary<FARAeroPartModule, int>(ObjectReferenceEqualityComparer<FARAeroPartModule>.Default);
             GenerateCrossFlowDragCurve();
         }
 

--- a/FerramAerospaceResearch/FARKSPAddonFlightScene.cs
+++ b/FerramAerospaceResearch/FARKSPAddonFlightScene.cs
@@ -49,6 +49,7 @@ using UnityEngine;
 using FerramAerospaceResearch.FARAeroComponents;
 using FerramAerospaceResearch.FARGUI;
 using ferram4;
+using FerramAerospaceResearch.FARThreading;
 
 namespace FerramAerospaceResearch
 {
@@ -62,6 +63,11 @@ namespace FerramAerospaceResearch
             FARAeroStress.LoadStressTemplates();
             FARAeroUtil.LoadAeroDataFromConfig();
             FARAnimOverrides.LoadAnimOverrides();
+        }
+
+        private void Update()
+        {
+            VoxelizationThreadpool.Instance.ExecuteMainThreadTasks();
         }
     }
 }

--- a/FerramAerospaceResearch/FARPartGeometry/VehicleVoxel.cs
+++ b/FerramAerospaceResearch/FARPartGeometry/VehicleVoxel.cs
@@ -89,7 +89,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
                 VoxelCrossSection[] array = new VoxelCrossSection[MaxArrayLength];
                 for (int i = 0; i < array.Length; i++)
                 {
-                    array[i].partSideAreaValues = new Dictionary<Part, VoxelCrossSection.SideAreaValues>();
+                    array[i].partSideAreaValues = new Dictionary<Part, VoxelCrossSection.SideAreaValues>(ObjectReferenceEqualityComparer<Part>.Default);
                 }
                 return array;
             }
@@ -146,7 +146,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
             Vector3d min = new Vector3d(double.PositiveInfinity, double.PositiveInfinity, double.PositiveInfinity);
             Vector3d max = new Vector3d(double.NegativeInfinity, double.NegativeInfinity, double.NegativeInfinity);
 
-            overridingParts = new HashSet<Part>();
+            overridingParts = new HashSet<Part>(ObjectReferenceEqualityComparer<Part>.Default);
             ductingParts = new HashSet<Part>();
             //Determine bounds and "overriding parts" from geoModules
             for (int i = 0; i < geoModules.Count; i++)
@@ -159,7 +159,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
                     while (!m.Ready)
                     {
                         Thread.SpinWait(5);
-                        if (m == null)
+                        if ((object)m == null)
                         {
                             cont = false;
                             break;
@@ -243,7 +243,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
 
         private bool CheckPartForOverridingPartList(GeometryPartModule g)
         {
-            if (g.part == null)
+            if ((object)g.part == null)
                 return false;
 
             PartModuleList modules = g.part.Modules;
@@ -1574,20 +1574,29 @@ namespace FerramAerospaceResearch.FARPartGeometry
         {
             try
             {
-                VoxelShellMeshParams meshParams = (VoxelShellMeshParams)meshParamsObject;
-                for (int i = meshParams.lowerIndex; i < meshParams.upperIndex; i++)
+                var meshes = new List<object>();
+                VoxelizationThreadpool.Instance.RunOnMainThread(() =>
                 {
-                    GeometryPartModule module = meshParams.modules[i];
-                    if (module == null || !module.Valid)
-                        continue;
-
-                    for(int j = 0; j < module.meshDataList.Count; j++)
+                    VoxelShellMeshParams meshParams = (VoxelShellMeshParams)meshParamsObject;
+                    for (int i = meshParams.lowerIndex; i < meshParams.upperIndex; i++)
                     {
-                        GeometryMesh mesh = module.meshDataList[j];
-                        lock (mesh)
-                            if (mesh.meshTransform.gameObject.activeInHierarchy && mesh.valid)
-                                UpdateFromMesh(mesh, mesh.part);
+                        GeometryPartModule module = meshParams.modules[i];
+                        if (module == null || !module.Valid)
+                            continue;
+
+                        for (int j = 0; j < module.meshDataList.Count; j++)
+                        {
+                            GeometryMesh mesh = module.meshDataList[j];
+                            lock (mesh)
+                                if (mesh.meshTransform.gameObject.activeInHierarchy && mesh.valid)
+                                    meshes.Add(mesh);
+                        }
                     }
+                });
+                foreach(var obj in meshes)
+                {
+                    var mesh = (GeometryMesh)obj;
+                    UpdateFromMesh(mesh, mesh.part);
                 }
             }
             catch (Exception e)

--- a/FerramAerospaceResearch/ObjectReferenceEqualityComparer.cs
+++ b/FerramAerospaceResearch/ObjectReferenceEqualityComparer.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+
+namespace FerramAerospaceResearch
+{
+    public class ObjectReferenceEqualityComparer<T> : EqualityComparer<T>
+    where T : class
+    {
+        private static IEqualityComparer<T> _defaultComparer;
+
+        public new static IEqualityComparer<T> Default
+        {
+            get { return _defaultComparer ?? (_defaultComparer = new ObjectReferenceEqualityComparer<T>()); }
+        }
+
+        #region IEqualityComparer<T> Members
+
+        public override bool Equals(T x, T y)
+        {
+            return ReferenceEquals(x, y);
+        }
+
+        public override int GetHashCode(T obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
+
+        #endregion
+    }
+}


### PR DESCRIPTION
In order to debug code with the procedure described [here](http://forum.kerbalspaceprogram.com/index.php?/topic/102909-ksp-plugin-debugging-for-visual-studio-and-monodevelop-on-all-os/&page=1), the code must not access Unity API from a thread that is not the main one. Since FAR uses multithreading for high performance voxelization, it throws several exceptions when running in such an environment, and doesn't actually produce any drag or lift.

I've updated the code to make it work correctly. Most cases were just about the overloaded == operator, but some parts are now delegated to the main thread (checking object existence, etc.), which could have a negative impact on performances (it makes the voxelization thread wait until the next main thread update). Which is why I detect at startup wether it's a vanilla Unity or the KSP version that runs, and choose the appropriate execution path, so that performance drop, if any, would be only for modders that want debugging tools.

Since this work can help other modders (both those that work on FAR, maybe including yourself, and those that work on another mod that depends on FAR), I wanted to share it, but I'd understand if you don't want the added code complexity.