### PR TITLE
Add null-check around access of prefab-part's model transforms

### DIFF
--- a/FerramAerospaceResearch/FARPartGeometry/GeometryPartModule.cs
+++ b/FerramAerospaceResearch/FARPartGeometry/GeometryPartModule.cs
@@ -666,7 +666,7 @@ namespace FerramAerospaceResearch.FARPartGeometry
                 if (!part.Modules.Contains<ModuleProceduralFairing>())
                 {
                     Transform prefabTransform = part.partInfo.partPrefab.FindModelTransform(t.gameObject.name);
-                    if (prefabTransform != null && prefabTransform.gameObject.layer == ignoreLayer0)
+                    if ((object)prefabTransform != null && prefabTransform.gameObject.layer == ignoreLayer0)
                     {
                         return null;
                     }

--- a/FerramAerospaceResearch/FARPartGeometry/GeometryPartModule.cs
+++ b/FerramAerospaceResearch/FARPartGeometry/GeometryPartModule.cs
@@ -662,10 +662,15 @@ namespace FerramAerospaceResearch.FARPartGeometry
                 m = mf.sharedMesh;
 
                 //MeshRenderer mr = t.GetComponent<MeshRenderer>();
-                
-                if(!part.Modules.Contains<ModuleProceduralFairing>())
-                    if (part.partInfo.partPrefab.FindModelTransform(t.gameObject.name).gameObject.layer == ignoreLayer0)
+
+                if (!part.Modules.Contains<ModuleProceduralFairing>())
+                {
+                    Transform prefabTransform = part.partInfo.partPrefab.FindModelTransform(t.gameObject.name);
+                    if (prefabTransform != null && prefabTransform.gameObject.layer == ignoreLayer0)
+                    {
                         return null;
+                    }
+                }
 
                 return new MeshData(m.vertices, m.triangles, m.bounds);
             }


### PR DESCRIPTION
For cases where transforms do not exist on the prefab (procedural/modular parts).

PR-fix for #148 

Please let me know if anything needs changed/fixed.
