### PR TITLE
Reduce garbage production by FlightGUI

### DIFF
--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightDataGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightDataGUI.cs
@@ -67,8 +67,9 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         };
 
         VesselFlightInfo infoParameters;
-        private string labelString, dataString;
-	StringBuilder dataReadoutString = new StringBuilder();
+	StringBuilder dataStringBuilder = new StringBuilder();
+	StringBuilder labelStringBuilder = new StringBuilder();
+
         GUIStyle buttonStyle;
         GUIStyle boxStyle;
 
@@ -92,145 +93,148 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             {
                 change |= (oldFlightDataSections[i] == activeFlightDataSections[i]);
             }
-            if(!change && labelString != null &&labelString.Length!=0)
+            if(!change && labelStringBuilder.Length != 0) //no need to recreate string, we still have one, and the settings have not been changed.
                 return;
             for(int i=0; i<activeFlightDataSections.Length;++i)
             {
                oldFlightDataSections[i] = activeFlightDataSections[i];
             }
 
-            dataReadoutString.Length = 0;
-            dataReadoutString.AppendLine();
+            labelStringBuilder.Length = 0;
+            labelStringBuilder.AppendLine();
             if (activeFlightDataSections[0])        //PYR angles
             {
-                dataReadoutString.AppendLine("Pitch Angle: \n\rHeading: \n\rRoll Angle: ");
-                dataReadoutString.AppendLine();
+                labelStringBuilder.AppendLine("Pitch Angle: \n\rHeading: \n\rRoll Angle: ");
+                labelStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[1])        //AoA and sidelip
             {
-                dataReadoutString.AppendLine("Angle of Attack: \n\rSideslip Angle: ");
-                dataReadoutString.AppendLine();
+                labelStringBuilder.AppendLine("Angle of Attack: \n\rSideslip Angle: ");
+                labelStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[2])        //Dyn pres
             {
-                dataReadoutString.AppendLine("Dyn Pres: ");
-                dataReadoutString.AppendLine();
+                labelStringBuilder.AppendLine("Dyn Pres: ");
+                labelStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[3])        //Raw Forces
             {
-                dataReadoutString.AppendLine("Lift: \n\rDrag: \n\rSideForce: ");
-                dataReadoutString.AppendLine();
+                labelStringBuilder.AppendLine("Lift: \n\rDrag: \n\rSideForce: ");
+                labelStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[4])        //Coeffs + refArea
             {
-                dataReadoutString.AppendLine("Cl: \n\rCd: \n\rCy: \n\rRef Area: ");
-                dataReadoutString.AppendLine();
+                labelStringBuilder.AppendLine("Cl: \n\rCd: \n\rCy: \n\rRef Area: ");
+                labelStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[5])        //L/D and VL/D
             {
-                dataReadoutString.AppendLine("L/D: \n\rV*L/D: ");
-                dataReadoutString.AppendLine();
+                labelStringBuilder.AppendLine("L/D: \n\rV*L/D: ");
+                labelStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[6])        //Engine and intake data
             {
 
-                dataReadoutString.AppendLine("Fuel Fraction: \n\rTSFC: \n\rAir Req Met: \n\rSpec. Excess Pwr:");
-                dataReadoutString.AppendLine();
+                labelStringBuilder.AppendLine("Fuel Fraction: \n\rTSFC: \n\rAir Req Met: \n\rSpec. Excess Pwr:");
+                labelStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[7])        //Range, Endurance est
             {
-                dataReadoutString.AppendLine("Est. Endurance: \n\rEst. Range: ");
-                dataReadoutString.AppendLine();
+                labelStringBuilder.AppendLine("Est. Endurance: \n\rEst. Range: ");
+                labelStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[8])        //Ballistic Coeff and Term Vel
             {
-                dataReadoutString.AppendLine("BC: \n\rTerminal V: ");
-                dataReadoutString.AppendLine();
+                labelStringBuilder.AppendLine("BC: \n\rTerminal V: ");
+                labelStringBuilder.AppendLine();
             }
-            labelString = dataReadoutString.ToString();
         }
 
         void CreateDataString()
         {
-            dataReadoutString.Length = 0;
-            dataReadoutString.AppendLine();
+            dataStringBuilder.Length = 0;
+            dataStringBuilder.AppendLine();
             if (activeFlightDataSections[0])        //PYR angles
             {
-                dataReadoutString.Concat((float)(infoParameters.pitchAngle),1);
-                dataReadoutString.AppendLine("°");
-		dataReadoutString.Concat((float)(infoParameters.headingAngle),1);
-                dataReadoutString.AppendLine("°");
-		dataReadoutString.Concat((float)(infoParameters.rollAngle),1);
-                dataReadoutString.AppendLine("°");
-                dataReadoutString.AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.pitchAngle),1);
+                dataStringBuilder.AppendLine("°");
+		dataStringBuilder.Concat((float)(infoParameters.headingAngle),1);
+                dataStringBuilder.AppendLine("°");
+		dataStringBuilder.Concat((float)(infoParameters.rollAngle),1);
+                dataStringBuilder.AppendLine("°");
+                dataStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[1])        //AoA and sidelip
             {
-                dataReadoutString.Concat((float)(infoParameters.aoA),1);
-                dataReadoutString.AppendLine("°");
-                dataReadoutString.Concat((float)(infoParameters.sideslipAngle),1);
-                dataReadoutString.AppendLine("°");
-                dataReadoutString.AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.aoA),1);
+                dataStringBuilder.AppendLine("°");
+                dataStringBuilder.Concat((float)(infoParameters.sideslipAngle),1);
+                dataStringBuilder.AppendLine("°");
+                dataStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[2])        //Dyn pres
             {
-                dataReadoutString.Concat((float)(infoParameters.dynPres),3);
-                dataReadoutString.AppendLine(" kPa");
-                dataReadoutString.AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.dynPres),3);
+                dataStringBuilder.AppendLine(" kPa");
+                dataStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[3])        //Raw Forces
             {
-                dataReadoutString.Concat((float)(infoParameters.liftForce),3);
-                dataReadoutString.AppendLine(" kN");
-                dataReadoutString.Concat((float)(infoParameters.dragForce),3);
-                dataReadoutString.AppendLine(" kN");
-                dataReadoutString.Concat((float)(infoParameters.sideForce),3);
-                dataReadoutString.AppendLine(" kN");
-                dataReadoutString.AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.liftForce),3);
+                dataStringBuilder.AppendLine(" kN");
+                dataStringBuilder.Concat((float)(infoParameters.dragForce),3);
+                dataStringBuilder.AppendLine(" kN");
+                dataStringBuilder.Concat((float)(infoParameters.sideForce),3);
+                dataStringBuilder.AppendLine(" kN");
+                dataStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[4])        //Coeffs + refArea
             {
-                dataReadoutString.Concat((float)(infoParameters.liftCoeff),4).AppendLine();
-                dataReadoutString.Concat((float)(infoParameters.dragCoeff),4).AppendLine();
-                dataReadoutString.Concat((float)(infoParameters.sideCoeff),4).AppendLine();
-                dataReadoutString.Concat((float)(infoParameters.refArea),3);
-                dataReadoutString.AppendLine(" m²");
-                dataReadoutString.AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.liftCoeff),4).AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.dragCoeff),4).AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.sideCoeff),4).AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.refArea),3);
+                dataStringBuilder.AppendLine(" m²");
+                dataStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[5])        //L/D and VL/D
             {
-                dataReadoutString.Concat((float)(infoParameters.liftToDragRatio),3).AppendLine();
-                dataReadoutString.Concat((float)(infoParameters.velocityLiftToDragRatio),3).AppendLine();
-                dataReadoutString.AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.liftToDragRatio),3).AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.velocityLiftToDragRatio),3).AppendLine();
+                dataStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[6])        //Engine and intake data
             {
-                dataReadoutString.Concat((float)((infoParameters.fullMass - infoParameters.dryMass) / infoParameters.fullMass),2).AppendLine();
-                dataReadoutString.Concat((float)(infoParameters.tSFC),3);
-                dataReadoutString.AppendLine(" hr⁻¹");
-                dataReadoutString.Concat((float)(infoParameters.intakeAirFrac * 100),1); //Note: Originally this was output using P1 format, leading to an effective factor of 100*100.
-                dataReadoutString.AppendLine("%");
-                dataReadoutString.Concat((float)(infoParameters.specExcessPower),2); //this is a noticable change to original code: Here N2 format was used...
-                dataReadoutString.AppendLine(" W/kg");
-                dataReadoutString.AppendLine();
+                dataStringBuilder.Concat((float)((infoParameters.fullMass - infoParameters.dryMass) / infoParameters.fullMass),2).AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.tSFC),3);
+                dataStringBuilder.AppendLine(" hr⁻¹");
+                if(double.IsInfinity(infoParameters.intakeAirFrac))
+                    dataStringBuilder.AppendLine("Infinity");
+                else
+                {
+                    dataStringBuilder.Concat((float)(infoParameters.intakeAirFrac * 100),1); //Note: Originally this was output using P1 format, leading to an effective factor of 100*100.
+                    dataStringBuilder.AppendLine("%");
+                }
+                dataStringBuilder.Concat((float)(infoParameters.specExcessPower),2); //this is a noticable change to original code: Here N2 format was used...
+                dataStringBuilder.AppendLine(" W/kg");
+                dataStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[7])        //Range, Endurance est
             {
-                dataReadoutString.Concat((float)(infoParameters.endurance),2);
-                dataReadoutString.AppendLine(" hr");
-                dataReadoutString.Concat((float)(infoParameters.range),2); //also here: originall N2 format.
-                dataReadoutString.AppendLine(" km");
-                dataReadoutString.AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.endurance),2);
+                dataStringBuilder.AppendLine(" hr");
+                dataStringBuilder.Concat((float)(infoParameters.range),2); //also here: originall N2 format.
+                dataStringBuilder.AppendLine(" km");
+                dataStringBuilder.AppendLine();
             }
             if (activeFlightDataSections[8])        //Ballistic Coeff and Term Vel
             {
-                dataReadoutString.Concat((float)(infoParameters.ballisticCoeff),2);
-                dataReadoutString.AppendLine(" kg/m²");
-                dataReadoutString.Concat((float)(infoParameters.termVelEst),2);
-                dataReadoutString.AppendLine(" m/s");
-                dataReadoutString.AppendLine();
+                dataStringBuilder.Concat((float)(infoParameters.ballisticCoeff),2);
+                dataStringBuilder.AppendLine(" kg/m²");
+                dataStringBuilder.Concat((float)(infoParameters.termVelEst),2);
+                dataStringBuilder.AppendLine(" m/s");
+                dataStringBuilder.AppendLine();
             }
-            dataString = dataReadoutString.ToString();
         }
 
         public void DataDisplay()
@@ -246,10 +250,10 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             
             GUILayout.BeginHorizontal();
             GUILayout.BeginVertical();
-            GUILayout.Box(labelString, boxStyle, GUILayout.Width(140));
+            GUILayout.Box(labelStringBuilder.ToString(), boxStyle, GUILayout.Width(140));
             GUILayout.EndVertical();
             GUILayout.BeginVertical();
-            GUILayout.Box(dataString, boxStyle, GUILayout.Width(140));
+            GUILayout.Box(dataStringBuilder.ToString(), boxStyle, GUILayout.Width(140));
             GUILayout.EndVertical();
             GUILayout.EndHorizontal();
         }

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightDataGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightDataGUI.cs
@@ -45,6 +45,7 @@ Copyright 2015, Michael Ferrara, aka Ferram4
 using System;
 using System.Collections.Generic;
 using System.Text;
+using StringLeakTest;
 using UnityEngine;
 
 namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
@@ -155,79 +156,77 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             dataReadoutString.AppendLine();
             if (activeFlightDataSections[0])        //PYR angles
             {
-                dataReadoutString.Append(infoParameters.pitchAngle.ToString("N1"));
+                dataReadoutString.Concat((float)(infoParameters.pitchAngle),1);
                 dataReadoutString.AppendLine("°");
-                dataReadoutString.Append(infoParameters.headingAngle.ToString("N1"));
+		dataReadoutString.Concat((float)(infoParameters.headingAngle),1);
                 dataReadoutString.AppendLine("°");
-                dataReadoutString.Append(infoParameters.rollAngle.ToString("N1"));
+		dataReadoutString.Concat((float)(infoParameters.rollAngle),1);
                 dataReadoutString.AppendLine("°");
                 dataReadoutString.AppendLine();
             }
             if (activeFlightDataSections[1])        //AoA and sidelip
             {
-                dataReadoutString.Append(infoParameters.aoA.ToString("N1"));
+                dataReadoutString.Concat((float)(infoParameters.aoA),1);
                 dataReadoutString.AppendLine("°");
-                dataReadoutString.Append(infoParameters.sideslipAngle.ToString("N1"));
+                dataReadoutString.Concat((float)(infoParameters.sideslipAngle),1);
                 dataReadoutString.AppendLine("°");
                 dataReadoutString.AppendLine();
             }
             if (activeFlightDataSections[2])        //Dyn pres
             {
-                dataReadoutString.Append(infoParameters.dynPres.ToString("F3"));
+                dataReadoutString.Concat((float)(infoParameters.dynPres),3);
                 dataReadoutString.AppendLine(" kPa");
                 dataReadoutString.AppendLine();
             }
             if (activeFlightDataSections[3])        //Raw Forces
             {
-                dataReadoutString.Append(infoParameters.liftForce.ToString("F3"));
+                dataReadoutString.Concat((float)(infoParameters.liftForce),3);
                 dataReadoutString.AppendLine(" kN");
-                dataReadoutString.Append(infoParameters.dragForce.ToString("F3"));
+                dataReadoutString.Concat((float)(infoParameters.dragForce),3);
                 dataReadoutString.AppendLine(" kN");
-                dataReadoutString.Append(infoParameters.sideForce.ToString("F3"));
+                dataReadoutString.Concat((float)(infoParameters.sideForce),3);
                 dataReadoutString.AppendLine(" kN");
                 dataReadoutString.AppendLine();
             }
             if (activeFlightDataSections[4])        //Coeffs + refArea
             {
-                dataReadoutString.AppendLine(infoParameters.liftCoeff.ToString("F4"));
-                dataReadoutString.AppendLine(infoParameters.dragCoeff.ToString("F4"));
-                dataReadoutString.AppendLine(infoParameters.sideCoeff.ToString("F4"));
-                dataReadoutString.Append(infoParameters.refArea.ToString("F3"));
+                dataReadoutString.Concat((float)(infoParameters.liftCoeff),4).AppendLine();
+                dataReadoutString.Concat((float)(infoParameters.dragCoeff),4).AppendLine();
+                dataReadoutString.Concat((float)(infoParameters.sideCoeff),4).AppendLine();
+                dataReadoutString.Concat((float)(infoParameters.refArea),3);
                 dataReadoutString.AppendLine(" m²");
                 dataReadoutString.AppendLine();
             }
             if (activeFlightDataSections[5])        //L/D and VL/D
             {
-                dataReadoutString.AppendLine(infoParameters.liftToDragRatio.ToString("F3"));
-                dataReadoutString.AppendLine(infoParameters.velocityLiftToDragRatio.ToString("F3"));
+                dataReadoutString.Concat((float)(infoParameters.liftToDragRatio),3).AppendLine();
+                dataReadoutString.Concat((float)(infoParameters.velocityLiftToDragRatio),3).AppendLine();
                 dataReadoutString.AppendLine();
             }
             if (activeFlightDataSections[6])        //Engine and intake data
             {
-
-                dataReadoutString.AppendLine(((infoParameters.fullMass - infoParameters.dryMass) / infoParameters.fullMass).ToString("N2"));
-                dataReadoutString.Append(infoParameters.tSFC.ToString("N3"));
+                dataReadoutString.Concat((float)((infoParameters.fullMass - infoParameters.dryMass) / infoParameters.fullMass),2).AppendLine();
+                dataReadoutString.Concat((float)(infoParameters.tSFC),3);
                 dataReadoutString.AppendLine(" hr⁻¹");
-                dataReadoutString.AppendLine((infoParameters.intakeAirFrac * 100).ToString("P1"));
-                dataReadoutString.Append(infoParameters.specExcessPower.ToString("N2"));
+                dataReadoutString.Concat((float)(infoParameters.intakeAirFrac * 100),1); //Note: Originally this was output using P1 format, leading to an effective factor of 100*100.
+                dataReadoutString.AppendLine("%");
+                dataReadoutString.Concat((float)(infoParameters.specExcessPower),2); //this is a noticable change to original code: Here N2 format was used...
                 dataReadoutString.AppendLine(" W/kg");
                 dataReadoutString.AppendLine();
             }
             if (activeFlightDataSections[7])        //Range, Endurance est
             {
-
-                dataReadoutString.Append(infoParameters.endurance.ToString("N2"));
+                dataReadoutString.Concat((float)(infoParameters.endurance),2);
                 dataReadoutString.AppendLine(" hr");
-                dataReadoutString.Append(infoParameters.range.ToString("N2"));
+                dataReadoutString.Concat((float)(infoParameters.range),2); //also here: originall N2 format.
                 dataReadoutString.AppendLine(" km");
                 dataReadoutString.AppendLine();
             }
             if (activeFlightDataSections[8])        //Ballistic Coeff and Term Vel
             {
-
-                dataReadoutString.Append(infoParameters.ballisticCoeff.ToString("N2"));
+                dataReadoutString.Concat((float)(infoParameters.ballisticCoeff),2);
                 dataReadoutString.AppendLine(" kg/m²");
-                dataReadoutString.Append(infoParameters.termVelEst.ToString("N2"));
+                dataReadoutString.Concat((float)(infoParameters.termVelEst),2);
                 dataReadoutString.AppendLine(" m/s");
                 dataReadoutString.AppendLine();
             }

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightDataGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightDataGUI.cs
@@ -52,6 +52,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
     class FlightDataGUI
     {
         bool[] activeFlightDataSections = new bool[9] { true, true, true, true, true, true, true, true, true };
+        bool[] oldFlightDataSections = new bool[9] { false, false, false, false, false, false, false, false, false };
         string[] flightDataOptionLabels = new string[9]{
             "PYR Angles",
             "AoA + Sideslip",
@@ -65,9 +66,12 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         };
 
         VesselFlightInfo infoParameters;
-        string labelString, dataString;
+        private string labelString, dataString;
+	StringBuilder dataReadoutString = new StringBuilder();
         GUIStyle buttonStyle;
         GUIStyle boxStyle;
+
+	int thisFrame = 0;
 
         public FlightDataGUI()
         {
@@ -77,14 +81,24 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         public void UpdateInfoParameters(VesselFlightInfo info)
         {
             infoParameters = info;
-            CreateLabelString();
-            CreateDataString();
         }
 
 
         void CreateLabelString()
         {
-            StringBuilder dataReadoutString = new StringBuilder();
+            bool change = false;
+            for(int i=0; i<activeFlightDataSections.Length;++i)
+            {
+                change |= (oldFlightDataSections[i] == activeFlightDataSections[i]);
+            }
+            if(!change && labelString != null &&labelString.Length!=0)
+                return;
+            for(int i=0; i<activeFlightDataSections.Length;++i)
+            {
+               oldFlightDataSections[i] = activeFlightDataSections[i];
+            }
+
+            dataReadoutString.Length = 0;
             dataReadoutString.AppendLine();
             if (activeFlightDataSections[0])        //PYR angles
             {
@@ -137,7 +151,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
         void CreateDataString()
         {
-            StringBuilder dataReadoutString = new StringBuilder();
+            dataReadoutString.Length = 0;
             dataReadoutString.AppendLine();
             if (activeFlightDataSections[0])        //PYR angles
             {
@@ -224,8 +238,13 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         {
             if (boxStyle == null)
                 boxStyle = FlightGUI.boxStyle;
+            if(Time.frameCount != thisFrame)
+            {
+                thisFrame = Time.frameCount;
+                CreateLabelString();
+                CreateDataString();
+            }
             
-
             GUILayout.BeginHorizontal();
             GUILayout.BeginVertical();
             GUILayout.Box(labelString, boxStyle, GUILayout.Width(140));

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
@@ -48,6 +48,7 @@ using System.Text;
 using UnityEngine;
 using KSP;
 using KSP.UI.Screens;
+using StringLeakTest;
 using FerramAerospaceResearch.FARAeroComponents;
 using ferram4;
 
@@ -305,12 +306,15 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             GUILayout.BeginVertical(GUILayout.Height(100));
             GUILayout.BeginHorizontal();
             _strBuilder.Length = 0;
-            _strBuilder.AppendFormat("Mach: {0:F3}\n\rReynolds: {1:e2}", _vesselAero.MachNumber,_vesselAero.ReynoldsNumber);
+            _strBuilder.Append("Mach: ");
+            _strBuilder.Concat((float)(_vesselAero.MachNumber),3).AppendLine();
+            _strBuilder.AppendFormat("Reynolds: {1:e2}", _vesselAero.MachNumber,_vesselAero.ReynoldsNumber);
             GUILayout.Box(_strBuilder.ToString(), boxStyle, GUILayout.ExpandWidth(true));
             GUILayout.EndHorizontal();
 
             _strBuilder.Length = 0;
-            _strBuilder.AppendFormat("ATM Density: {0:F3}",_vessel.atmDensity);
+            _strBuilder.Append("ATM Density: ");
+            _strBuilder.Concat((float)(vessel.atmDensity),3);
 
             GUILayout.Box(_strBuilder.ToString(), boxStyle, GUILayout.ExpandWidth(true));
 

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
@@ -159,6 +159,7 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
         void OnDestroy()
         {
+            FlightGUIDrawer.SetGUIActive(this,false);
             GameEvents.onShowUI.Remove(ShowUI);
             GameEvents.onHideUI.Remove(HideUI);
             SaveConfigs();
@@ -248,6 +249,11 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
             _flightStatusGUI.UpdateInfoParameters(infoParameters);
             _flightDataGUI.UpdateInfoParameters(infoParameters);
         }
+        
+        void Update()
+        {
+            FlightGUIDrawer.SetGUIActive(this,(_vessel == FlightGlobals.ActiveVessel && showGUI && showAllGUI));
+        }
 
         #endregion
 
@@ -262,8 +268,9 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
         #region GUI Functions
 
-        void OnGUI()
+        public void DrawGUI()
         {
+//Debug.LogError("DrawGui called for "+_vessel.name);
             GUI.skin = HighLogic.Skin;
             if(boxStyle == null)
             {

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
@@ -270,7 +270,6 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
 
         public void DrawGUI()
         {
-//Debug.LogError("DrawGui called for "+_vessel.name);
             GUI.skin = HighLogic.Skin;
             if(boxStyle == null)
             {

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUI.cs
@@ -68,6 +68,8 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         static int activeFlightGUICount = 0;
         public static Dictionary<Vessel, FlightGUI> vesselFlightGUI;
 
+        private StringBuilder _strBuilder = new StringBuilder();
+
         PhysicsCalcs _physicsCalcs;
         VesselFlightInfo infoParameters;
         public VesselFlightInfo InfoParameters
@@ -302,10 +304,15 @@ namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
         {
             GUILayout.BeginVertical(GUILayout.Height(100));
             GUILayout.BeginHorizontal();
-            GUILayout.Box("Mach: " + _vesselAero.MachNumber.ToString("F3") + " \n\rReynolds: " + _vesselAero.ReynoldsNumber.ToString("e2"), boxStyle, GUILayout.ExpandWidth(true));
+            _strBuilder.Length = 0;
+            _strBuilder.AppendFormat("Mach: {0:F3}\n\rReynolds: {1:e2}", _vesselAero.MachNumber,_vesselAero.ReynoldsNumber);
+            GUILayout.Box(_strBuilder.ToString(), boxStyle, GUILayout.ExpandWidth(true));
             GUILayout.EndHorizontal();
 
-            GUILayout.Box("ATM Density: " + _vessel.atmDensity.ToString("F3"), boxStyle, GUILayout.ExpandWidth(true));
+            _strBuilder.Length = 0;
+            _strBuilder.AppendFormat("ATM Density: {0:F3}",_vessel.atmDensity);
+
+            GUILayout.Box(_strBuilder.ToString(), boxStyle, GUILayout.ExpandWidth(true));
 
             _flightStatusGUI.Display();
             showFlightDataWindow = GUILayout.Toggle(showFlightDataWindow, "Flt Data", buttonStyle, GUILayout.ExpandWidth(true));

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUIDrawer.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/FlightGUIDrawer.cs
@@ -1,0 +1,97 @@
+﻿/*
+Ferram Aerospace Research v0.15.7.2 "Lanchester"
+=========================
+Aerodynamics model for Kerbal Space Program
+
+Copyright 2015, Michael Ferrara, aka Ferram4
+
+   This file is part of Ferram Aerospace Research.
+
+   Ferram Aerospace Research is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   Ferram Aerospace Research is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with Ferram Aerospace Research.  If not, see <http://www.gnu.org/licenses/>.
+
+   Serious thanks:		a.g., for tons of bugfixes and code-refactorings   
+				stupid_chris, for the RealChuteLite implementation
+            			Taverius, for correcting a ton of incorrect values  
+				Tetryds, for finding lots of bugs and issues and not letting me get away with them, and work on example crafts
+            			sarbian, for refactoring code for working with MechJeb, and the Module Manager updates  
+            			ialdabaoth (who is awesome), who originally created Module Manager  
+                        	Regex, for adding RPM support  
+				DaMichel, for some ferramGraph updates and some control surface-related features  
+            			Duxwing, for copy editing the readme  
+   
+   CompatibilityChecker by Majiir, BSD 2-clause http://opensource.org/licenses/BSD-2-Clause
+
+   Part.cfg changes powered by sarbian & ialdabaoth's ModuleManager plugin; used with permission  
+	http://forum.kerbalspaceprogram.com/threads/55219
+
+   ModularFLightIntegrator by Sarbian, Starwaster and Ferram4, MIT: http://opensource.org/licenses/MIT
+	http://forum.kerbalspaceprogram.com/threads/118088
+
+   Toolbar integration powered by blizzy78's Toolbar plugin; used with permission  
+	http://forum.kerbalspaceprogram.com/threads/60863
+ */
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using UnityEngine;
+using KSP;
+using KSP.UI.Screens;
+using FerramAerospaceResearch.FARAeroComponents;
+using ferram4;
+
+namespace FerramAerospaceResearch.FARGUI.FARFlightGUI
+{
+    [KSPAddon(KSPAddon.Startup.Flight, false)]
+    public class FlightGUIDrawer : MonoBehaviour
+    {
+        private static FlightGUIDrawer instance;
+        private static List<FlightGUI> activeGUIs = new List<FlightGUI>(); //this could be a HashSet as well, but iterating over those causes garbage.
+        
+        public static FlightGUIDrawer Instance
+        {
+            get { return instance; }
+        }
+
+        void Start()
+        {
+            if (CompatibilityChecker.IsAllCompatible() && instance == null)
+                instance = this;
+            else
+            {
+                GameObject.Destroy(this);
+                return;
+            }
+        }
+        
+        public static void SetGUIActive(FlightGUI Gui, bool state)
+        {
+            if(state)
+            {
+                if(!activeGUIs.Contains(Gui))
+                    activeGUIs.Add(Gui);
+            }
+            else
+                activeGUIs.Remove(Gui);
+        }
+        
+        void OnGUI()
+        {
+            for(int i = 0 ; i < activeGUIs.Count; ++i)
+            {
+                activeGUIs[i].DrawGUI();
+            }
+        }
+    }
+}

--- a/FerramAerospaceResearch/FARGUI/FARFlightGUI/StringBuilderExtNumeric.cs
+++ b/FerramAerospaceResearch/FARGUI/FARFlightGUI/StringBuilderExtNumeric.cs
@@ -1,0 +1,202 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// File:	StringBuilderExtNumeric.cs
+// Date:	9th March 2010
+// Author:	Gavin Pugh
+// Details:	Extension methods for the 'StringBuilder' standard .NET class, to allow garbage-free concatenation of
+//			a selection of simple numeric types.  
+//
+// Copyright (c) Gavin Pugh 2010 - Released under the zlib license: http://www.opensource.org/licenses/zlib-license.php
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Diagnostics;
+
+namespace StringLeakTest
+{
+	public static partial class StringBuilderExtensions
+	{
+		// These digits are here in a static array to support hex with simple, easily-understandable code. 
+		// Since A-Z don't sit next to 0-9 in the ascii table.
+		private static readonly char[]	ms_digits = new char[] { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F' };
+
+		private static readonly uint	ms_default_decimal_places = 5; //< Matches standard .NET formatting dp's
+		private static readonly char	ms_default_pad_char = '0';
+
+		//! Convert a given unsigned integer value to a string and concatenate onto the stringbuilder. Any base value allowed.
+		public static StringBuilder Concat( this StringBuilder string_builder, uint uint_val, uint pad_amount, char pad_char, uint base_val )
+		{
+			Debug.Assert( pad_amount >= 0 );
+			Debug.Assert( base_val > 0 && base_val <= 16 );
+
+			// Calculate length of integer when written out
+			uint length = 0;
+			uint length_calc = uint_val;
+
+			do
+			{
+				length_calc /= base_val;
+				length++;
+			}
+			while ( length_calc > 0 );
+
+			// Pad out space for writing.
+			string_builder.Append( pad_char, (int)Math.Max( pad_amount, length ));
+
+			int strpos = string_builder.Length;
+
+			// We're writing backwards, one character at a time.
+			while ( length > 0 )
+			{
+				strpos--;
+
+				// Lookup from static char array, to cover hex values too
+				string_builder[strpos] = ms_digits[uint_val % base_val];
+
+				uint_val /= base_val;
+				length--;
+			}
+
+			return string_builder;
+		}
+
+		//! Convert a given unsigned integer value to a string and concatenate onto the stringbuilder. Assume no padding and base ten.
+		public static StringBuilder Concat( this StringBuilder string_builder, uint uint_val )
+		{
+			string_builder.Concat( uint_val, 0, ms_default_pad_char, 10 );
+			return string_builder;
+		}
+
+		//! Convert a given unsigned integer value to a string and concatenate onto the stringbuilder. Assume base ten.
+		public static StringBuilder Concat( this StringBuilder string_builder, uint uint_val, uint pad_amount )
+		{
+			string_builder.Concat( uint_val, pad_amount, ms_default_pad_char, 10 );
+			return string_builder;
+		}
+
+		//! Convert a given unsigned integer value to a string and concatenate onto the stringbuilder. Assume base ten.
+		public static StringBuilder Concat( this StringBuilder string_builder, uint uint_val, uint pad_amount, char pad_char )
+		{
+			string_builder.Concat( uint_val, pad_amount, pad_char, 10 );
+			return string_builder;
+		}
+
+		//! Convert a given signed integer value to a string and concatenate onto the stringbuilder. Any base value allowed.
+		public static StringBuilder Concat( this StringBuilder string_builder, int int_val, uint pad_amount, char pad_char, uint base_val )
+		{
+			Debug.Assert( pad_amount >= 0 );
+			Debug.Assert( base_val > 0 && base_val <= 16 );
+
+			// Deal with negative numbers
+			if (int_val < 0)
+			{
+				string_builder.Append( '-' );
+				uint uint_val = uint.MaxValue - ((uint) int_val ) + 1; //< This is to deal with Int32.MinValue
+				string_builder.Concat( uint_val, pad_amount, pad_char, base_val );
+			}
+			else
+			{
+				string_builder.Concat((uint)int_val, pad_amount, pad_char, base_val );
+			}
+
+			return string_builder;
+		}
+
+		//! Convert a given signed integer value to a string and concatenate onto the stringbuilder. Assume no padding and base ten.
+		public static StringBuilder Concat( this StringBuilder string_builder, int int_val )
+		{
+			string_builder.Concat( int_val, 0, ms_default_pad_char, 10 );
+			return string_builder;
+		}
+
+		//! Convert a given signed integer value to a string and concatenate onto the stringbuilder. Assume base ten.
+		public static StringBuilder Concat( this StringBuilder string_builder, int int_val, uint pad_amount )
+		{
+			string_builder.Concat( int_val, pad_amount, ms_default_pad_char, 10 );
+			return string_builder;
+		}
+
+		//! Convert a given signed integer value to a string and concatenate onto the stringbuilder. Assume base ten.
+		public static StringBuilder Concat( this StringBuilder string_builder, int int_val, uint pad_amount, char pad_char )
+		{
+			string_builder.Concat( int_val, pad_amount, pad_char, 10 );
+			return string_builder;
+		}
+
+		//! Convert a given float value to a string and concatenate onto the stringbuilder
+		public static StringBuilder Concat( this StringBuilder string_builder, float float_val, uint decimal_places, uint pad_amount, char pad_char )
+		{
+			Debug.Assert( pad_amount >= 0 );
+
+			if ( decimal_places == 0 )
+			{
+				// No decimal places, just round up and print it as an int
+
+				// Agh, Math.Floor() just works on doubles/decimals. Don't want to cast! Let's do this the old-fashioned way.
+				int int_val;
+				if ( float_val >= 0.0f )
+				{
+					// Round up
+					int_val = (int)( float_val + 0.5f );
+				}
+				else
+				{
+					// Round down for negative numbers
+					int_val = (int)( float_val - 0.5f );
+				}
+
+				string_builder.Concat( int_val, pad_amount, pad_char, 10 );
+			}
+			else
+			{
+				int int_part = (int)float_val;
+
+				// First part is easy, just cast to an integer
+				string_builder.Concat( int_part, pad_amount, pad_char, 10 );
+
+				// Decimal point
+				string_builder.Append( '.' );
+
+				// Work out remainder we need to print after the d.p.
+				float remainder = Math.Abs( float_val - int_part );
+
+				// Multiply up to become an int that we can print
+				do
+				{
+					remainder *= 10;
+					decimal_places--;
+				}
+				while ( decimal_places > 0 );
+
+				// Round up. It's guaranteed to be a positive number, so no extra work required here.
+				remainder += 0.5f;
+
+				// All done, print that as an int!
+				string_builder.Concat( (uint)remainder, 0, '0', 10 );
+			}
+			return string_builder;
+		}
+		
+		//! Convert a given float value to a string and concatenate onto the stringbuilder. Assumes five decimal places, and no padding.
+		public static StringBuilder Concat(this StringBuilder string_builder, float float_val)
+		{
+			string_builder.Concat(float_val, ms_default_decimal_places, 0, ms_default_pad_char);
+			return string_builder;
+		}
+
+		//! Convert a given float value to a string and concatenate onto the stringbuilder. Assumes no padding.
+		public static StringBuilder Concat( this StringBuilder string_builder, float float_val, uint decimal_places )
+		{
+			string_builder.Concat (float_val, decimal_places, 0, ms_default_pad_char );
+			return string_builder;
+		}
+
+		//! Convert a given float value to a string and concatenate onto the stringbuilder.
+		public static StringBuilder Concat(this StringBuilder string_builder, float float_val, uint decimal_places, uint pad_amount)
+		{
+			string_builder.Concat(float_val, decimal_places, pad_amount, ms_default_pad_char);
+			return string_builder;
+		}
+	}
+}

--- a/FerramAerospaceResearch/FerramAerospaceResearch.csproj
+++ b/FerramAerospaceResearch/FerramAerospaceResearch.csproj
@@ -76,6 +76,7 @@
     <Compile Include="FARGUI\FARFlightGUI\AeroVisualizationGUI.cs" />
     <Compile Include="FARGUI\FARFlightGUI\AirspeedSettingsGUI.cs" />
     <Compile Include="FARGUI\FARFlightGUI\FlightStatusGUI.cs" />
+    <Compile Include="FARGUI\FARFlightGUI\FlightGUIDrawer.cs" />
     <Compile Include="FARGUI\FARFlightGUI\FlightDataGUI.cs" />
     <Compile Include="FARGUI\FARFlightGUI\InternalSpeedFAR.cs" />
     <Compile Include="FARGUI\FARFlightGUI\StabilityAugmentation.cs" />


### PR DESCRIPTION
The current dev-build of FAR creates megabytes of garbage under certain circumstances. The reason seems to be that FAR recreates the output texts for the flight data window every physics frame, for every vessel.

While I did not invest enough time to fix the underlying issue (namely, that FixedUpdate of the GUI seems to run for vessels outside of physics range), I did spend some time to work around the huge amount of garbage being created.

Commit 8f02298 moves the creation of the display strings from FixedUpdate() to DataDisplay(), and makes sure that it's only called once per frame per active DataDisplay. This is the one commit that I'd be really glad if it would be merged, as it makes a huge performance difference for my save (which has quite a few vessels).

The other commits are more cosmetic than necessary, and I don't know if you are happy with the added StringBuilder extension methods (which I found on the net, they are under zlib license). Anyhow, those changes (very) slightly decrease garbage further, but are by far not as important as 8f02298.