### PR TITLE
Mark .cfg files as text files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.cfg diff


### PR DESCRIPTION
Sometimes, Git shows something like
`warning: Cannot merge binary files: GameData/FerramAerospaceResearch/Localization/Localization.cfg (HEAD vs. upstream/ksp_update)`

Which is problematic.
This is a small fix that marks all files that end with _.cfg_ as text files.
It will make merging easier.