### PR TITLE
Simplify interpretation of some derivatives (#201).

### DIFF
--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSim.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/InstantConditionSim.cs
@@ -141,15 +141,15 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
             AngVel += (sinPhi * alphaDot - cosAlpha * cosPhi * betaDot) * up;
 
             Vector3d velocity = forward * cosAlpha * cosBeta;
-            velocity += right * (sinPhi * cosAlpha * cosBeta + cosPhi * sinBeta);
-            velocity += -up * cosPhi * (sinAlpha * cosBeta + sinBeta);
+            velocity += right * (sinPhi * sinAlpha * cosBeta + cosPhi * sinBeta); // Rodhern: Changed velocity 'right' and 'up' components 
+            velocity += -up * (cosPhi * sinAlpha * cosBeta - sinPhi * sinBeta);   //  to align vector to naive forward direction.
 
-            velocity.Normalize();
+            // velocity.Normalize(); // Rodhern: Normalize should no longer be needed.
 
             //this is negative wrt the ground
             Vector3d liftVector = -forward * sinAlpha + right * sinPhi * cosAlpha - up * cosPhi * cosAlpha;
 
-            Vector3d sideways = Vector3.Cross(velocity, liftVector).normalized;
+            Vector3d sideways = Vector3.Cross(velocity, liftVector); // .normalized; // Rodhern: Normalize should no longer be needed.
 
 
             for (int i = 0; i < _wingAerodynamicModel.Count; i++)

--- a/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/StabilityDerivCalculator.cs
+++ b/FerramAerospaceResearch/FARGUI/FAREditorGUI/Simulation/StabilityDerivCalculator.cs
@@ -275,8 +275,8 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
             pertOutput.Cd = (pertOutput.Cd - nominalOutput.Cd) / 0.05;
             pertOutput.Cm = (pertOutput.Cm - nominalOutput.Cm) / 0.05;
 
-            pertOutput.Cl *= q * area * MAC / (2 * u0 * mass);
-            pertOutput.Cd *= q * area * MAC / (2 * u0 * mass);
+            pertOutput.Cl *= -q * area * MAC / (2 * u0 * mass); // Rodhern: Replaced 'q' by '-q', so that formulas
+            pertOutput.Cd *= -q * area * MAC / (2 * u0 * mass); //  for Zq and Xq match those for Zu and Xu.
             pertOutput.Cm *= q * area * MAC * MAC / (2 * u0 * Iy);
 
             stabDerivOutput.stabDerivs[9] = pertOutput.Cl;  //Zq
@@ -292,8 +292,8 @@ namespace FerramAerospaceResearch.FARGUI.FAREditorGUI.Simulation
             pertOutput.Cd = (pertOutput.Cd - nominalOutput.Cd) / 0.1;
             pertOutput.Cm = (pertOutput.Cm - nominalOutput.Cm) / 0.1;
 
-            pertOutput.Cl *= q * area / mass;
-            pertOutput.Cd *= q * area / mass;
+            pertOutput.Cl *= -q * area / mass; // Rodhern: Replaced 'q' by '-q', so that formulas
+            pertOutput.Cd *= -q * area / mass; //  for Ze and Xe match those for Zu and Xu.
             pertOutput.Cm *= q * area * MAC / Iy;
 
             stabDerivOutput.stabDerivs[12] = pertOutput.Cl; //Ze


### PR DESCRIPTION
Proposed minor changes to stability derivatives as per #201. In short the main principles for the changes are:
* Lift and drag forces are opposite to the Z (down) and X (forward) directions; therefore positive derivatives to Cl and Cd are most sensibly presented as negative derivatives of Z and X forces.
* For modest pitch, yaw and roll angles, an increase in yaw angle should not greatly affect the craft's angle of attack (orthonormal set of 'velocity', 'liftVector' and 'sideways').