### PR TITLE
Fix Realchute module for RO installs

### DIFF
--- a/GameData/FerramAerospaceResearch/RealChuteLite/RealChuteLite.cfg
+++ b/GameData/FerramAerospaceResearch/RealChuteLite/RealChuteLite.cfg
@@ -1,5 +1,5 @@
 //If RealChute is installed, run after it
-@PART[*]:HAS[@MODULE[ModuleParachute]]:NEEDS[RealChute]:AFTER[RealChute]
+@PART[*]:HAS[@MODULE[ModuleParachute]]:NEEDS[RealChute&!RealismOverhaul]:AFTER[RealChute]
 {
         //Transform ModuleParachute into RealChute (removing ModuleParachute)
         @MODULE[ModuleParachute]


### PR DESCRIPTION
- @ferram4 This should not run on RealismOverhaul installs as the RO configs
already account for this. The config as it was, was adding duplicate
chute modules to all parachute parts that modified themselves inside the
RO configs. This change remedies that problem without affecting stock
installs.